### PR TITLE
Support Docker Compose 1.6.0

### DIFF
--- a/lib/docker/rails/cli/main.rb
+++ b/lib/docker/rails/cli/main.rb
@@ -73,8 +73,11 @@ module Docker
           invoke CLI::GemsetVolume, :create, [target], base_options
           invoke CLI::SshAgent, :forward, [target], base_options
 
-          compose_options = ''
-          compose_options = '-d' if options[:detached]
+          if options[:detached]
+            compose_options = '-d'
+          else
+            compose_options = '--abort-on-container-exit'
+          end
 
           app.up(compose_options)
         end


### PR DESCRIPTION
Use --abort-on-container-exit to make all docker containers exit when one container exits.  Without this change, docker-rails will hang and never exit when using Docker Compose 1.6.0+.  FYI I'm not sure if Docker Compose pre 1.6.0 will ignore this command line argument or not.
